### PR TITLE
Alternative link_to helper without trusting strings

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,9 +15,11 @@
           <i class="fa fa-bolt" aria-hidden="true"></i> <%= link_to "   fitrep", root_path %>
         </button>
       </div>
-      <ul class="nav navbar-top-links navbar-right">
-        <%= link_to '<i class="fa fa-plus" aria-hidden="true"></i>'.html_safe, new_workout_session_path, class: "new_workout_session btn navbar-btn btn-success" %>
-      </ul>
+      <div class="nav navbar-top-links navbar-right">
+        <%= link_to new_workout_session_path, class: "new_workout_session btn navbar-btn btn-success" do %>
+          <i class="fa fa-plus" aria-hidden="true"></i>
+        <% end %>
+      </div>
     </div>
   </nav>
 


### PR DESCRIPTION
You'd mentioned during your talk using an HTML-safe string embedded in a link, so I thought you might like to know about this version of the `link_to` helper. :-)

Basically, instead of:

``` erb
<%= link_to content_as_a_string.html_safe, url, class: 'foo' %>
```

it becomes …

``` erb
<%= link_to url, class: 'foo' do %>
  content
<% end %>
```

This way, you don't have to munge strings together and you can use HTML as a first-class citizen again. :-)

Also, this PR swaps out a `ul` tag for a `div`. In the HTML spec, a `ul` tag must only contain `li` tags as direct child nodes. Most browsers are pretty forgiving on stuff like this (which is why it does work in Chrome), but it's not guaranteed, so better safe than sorry. :-)
